### PR TITLE
Fixed scaling factors

### DIFF
--- a/lib/light.js
+++ b/lib/light.js
@@ -327,8 +327,8 @@ var Controllers = {
 
               // Page 27
               // CalculateLux(...)
-              ch0 = (ch0 * scale) >> 0x10;
-              ch1 = (ch1 * scale) >> 0x10;
+              ch0 = (ch0 * scale) >> 10;
+              ch1 = (ch1 * scale) >> 10;
 
               var ratio1 = 0;
 


### PR DESCRIPTION
Should be scaled by 2^10 bot by 2^16. See datasheet https://cdn-shop.adafruit.com/datasheets/TSL2561.pdf page 24